### PR TITLE
fix: fix a typo to raise error when duplicate pipeline exist

### DIFF
--- a/src/app_functions_sdk_py/internal/runtime/__init__.py
+++ b/src/app_functions_sdk_py/internal/runtime/__init__.py
@@ -141,7 +141,7 @@ class FunctionsPipelineRuntime:
         """
         pipeline = self._pipelines.get(pipeline_id)
         if pipeline is not None:
-            return errors.new_common_edgex(errors.ErrKind.STATUS_CONFLICT,
+            raise errors.new_common_edgex(errors.ErrKind.STATUS_CONFLICT,
                                            f"pipeline with Id='{pipeline_id}' already exists")
 
         self._add_function_pipeline(pipeline_id, topics, *transforms)


### PR DESCRIPTION
fixes https://github.com/edgexfoundry/app-functions-sdk-python/issues/10

When adding new pipeline with existing piepeline id, an error should be raised instead of return to ensure that caller can catch such errors.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Per description in https://github.com/edgexfoundry/app-functions-sdk-python/issues/10

## Issue Number:
https://github.com/edgexfoundry/app-functions-sdk-python/issues/10

## What is the new behavior?
The code should raise exception when duplicate pipeline id detected.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information