### PR TITLE
fix: Update reading id with default empty

### DIFF
--- a/src/app_functions_sdk_py/contracts/dtos/reading.py
+++ b/src/app_functions_sdk_py/contracts/dtos/reading.py
@@ -42,12 +42,12 @@ class BaseReading:
         value (str): The value of the reading.
         tags (Tags): The tags associated with the reading.
     """
-    id: str
     origin: int
     deviceName: str
     resourceName: str
     profileName: str
     valueType: str
+    id: str = ""
     # To allow value as null (https://github.com/edgexfoundry/go-mod-core-contracts/issues/931),
     # specify value as Optional[str]
     value: Optional[str] = None


### PR DESCRIPTION
The go-mod-core-contratcs defines reading DTO with omitempty id field. To sync with go-mod-core-contratcs, update the app-functions-sdk-python with defualt empty reading id.

https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/dtos/reading.go#L25

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information